### PR TITLE
Run the helloworld binary as the nobody user instead of root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,5 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflag
 FROM alpine:3.16
 COPY static /static
 COPY --from=builder /helloworld /helloworld
+USER nobody
 ENTRYPOINT ["/helloworld"]


### PR DESCRIPTION
I want to use this image in some testing, and our admission controllers in our k8s clusters and security contexts of our containers require that no containers run processes as root. 