### PR TITLE
fix: additionally tag newly built images as `latest` on push

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -119,6 +119,8 @@ jobs:
               --arch amd64 \
               ${target_image} "${target_image}-windows.ltsc2022";
           docker manifest push ${target_image};
+          docker tag "${target_image}" ${{ env.IMAGE_REPOSITORY }}:latest
+          docker push ${{ env.IMAGE_REPOSITORY }}:latest
 
   check-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
PR synchronizes `latest` tag when pushing release images to DockerHub