### PR TITLE
chore: install choco on windows base image for installing upx

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,9 @@ updates:
       open-pull-requests-limit: 3
       rebase-strategy: disabled
     - package-ecosystem: docker
-      directory: /
+      directories:
+        - /linux
+        - /windows
       schedule:
         interval: monthly
         day: sunday

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -6,7 +6,13 @@ ARG BASE_IMAGE
 FROM golang:1.25-nanoserver as builder
 ENV CGO_ENABLED=0
 
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
 WORKDIR /app
+
+RUN Set-ExecutionPolicy Bypass -Scope Process -Force; \
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; \
+    iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'));
 
 # Install source deps
 COPY go.mod go.sum ./


### PR DESCRIPTION
- **chore: install choco on Windows base image**
- **fix: update dependabot paths**
